### PR TITLE
fix: Add unique origin entity code

### DIFF
--- a/docs/4.4.1-release-notes.md
+++ b/docs/4.4.1-release-notes.md
@@ -3,3 +3,4 @@
 - Terminology changes
 
 ### Fix
+- Fix Topology not showing data from enricher

--- a/src/ExternalSearch.Providers.ClearBit/ClearBitExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.ClearBit/ClearBitExternalSearchProvider.cs
@@ -184,6 +184,7 @@ namespace CluedIn.ExternalSearch.Providers.ClearBit
             metadata.EntityType = request.EntityMetaData.EntityType;
             metadata.Name = request.EntityMetaData.Name;
             metadata.OriginEntityCode = code;
+            metadata.Codes.Add(request.EntityMetaData.OriginEntityCode);
 
             metadata.Properties[ClearBitVocabulary.Organization.Domain] = resultItem.Data.Domain;
             metadata.Properties[ClearBitVocabulary.Organization.Logo] = resultItem.Data.Logo;
@@ -281,9 +282,7 @@ namespace CluedIn.ExternalSearch.Providers.ClearBit
             var resultItem = result.As<CompanyAutocompleteResult>();
             var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "clearBit", $"{query.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
 
-            var clue = new Clue(code, context.Organization);
-            clue.Data.EntityData.Codes.Add(request.EntityMetaData.OriginEntityCode);
-            clue.Data.OriginProviderDefinitionId = this.Id;
+            var clue = new Clue(code, context.Organization) { Data = { OriginProviderDefinitionId = this.Id } };
 
             this.PopulateMetadata(clue.Data.EntityData, resultItem, request);
             this.DownloadPreviewImage(context, resultItem.Data.Logo, clue);

--- a/src/ExternalSearch.Providers.ClearBit/ClearBitExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.ClearBit/ClearBitExternalSearchProvider.cs
@@ -179,9 +179,11 @@ namespace CluedIn.ExternalSearch.Providers.ClearBit
         /// <param name="resultItem">The result item.</param>
         private void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<CompanyAutocompleteResult> resultItem, IExternalSearchRequest request)
         {
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "clearBit", $"{request.Queries.FirstOrDefault()?.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+
             metadata.EntityType = request.EntityMetaData.EntityType;
             metadata.Name = request.EntityMetaData.Name;
-            metadata.OriginEntityCode = request.EntityMetaData.OriginEntityCode;
+            metadata.OriginEntityCode = code;
 
             metadata.Properties[ClearBitVocabulary.Organization.Domain] = resultItem.Data.Domain;
             metadata.Properties[ClearBitVocabulary.Organization.Logo] = resultItem.Data.Logo;
@@ -277,8 +279,10 @@ namespace CluedIn.ExternalSearch.Providers.ClearBit
         public IEnumerable<Clue> BuildClues(ExecutionContext context, IExternalSearchQuery query, IExternalSearchQueryResult result, IExternalSearchRequest request, IDictionary<string, object> config, IProvider provider)
         {
             var resultItem = result.As<CompanyAutocompleteResult>();
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "clearBit", $"{query.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
 
-            var clue = new Clue(request.EntityMetaData.OriginEntityCode, context.Organization);
+            var clue = new Clue(code, context.Organization);
+            clue.Data.EntityData.Codes.Add(request.EntityMetaData.OriginEntityCode);
             clue.Data.OriginProviderDefinitionId = this.Id;
 
             this.PopulateMetadata(clue.Data.EntityData, resultItem, request);


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#47706](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/47706)

Topology now showing Clearbit data, but the previously one from web enricher disappeared
![image](https://github.com/user-attachments/assets/e8c9e7ab-4fc4-452c-a647-0ee1ab6dfb07)

## How has it been tested? <!-- Remove if not needed -->
Manually in local