### PR TITLE
feat: Update to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!-- TODO: Clean up warnings -->

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 4.0
+next-version: 5.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/Packages.props
+++ b/Packages.props
@@ -1,8 +1,7 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_ComponentHost>3.2.1</_ComponentHost>
-    <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>4.6.0</_CluedIn>
+    <_AutoFixture>5.0.0-preview0012</_AutoFixture>
+    <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--
@@ -10,18 +9,14 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Update="AutoFixture.Xunit2" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />
     <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
-    <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />
-    <PackageReference Update="xunit" Version="2.4.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Update="Xunit.SkippableFact" Version="1.3.12" />
+    <PackageReference Update="xunit.v3" Version="3.2.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Update="Moq" Version="4.13.1" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
-    <PackageReference Update="CluedIn.Testing.Base" Version="4.0.0" />
+    <PackageReference Update="CluedIn.Testing.Base" Version="5.0.0-*" />
   </ItemGroup>
   <ItemGroup>
     <!--
@@ -29,7 +24,6 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="ComponentHost" Version="$(_ComponentHost)" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.ExternalSearch" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Processing" Version="$(_CluedIn)" />

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestFeature",
-    "allowPrerelease": "false"
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52"

--- a/src/ExternalSearch.Providers.ClearBit.Provider/Provider.ExternalSearch.ClearBit.csproj
+++ b/src/ExternalSearch.Providers.ClearBit.Provider/Provider.ExternalSearch.ClearBit.csproj
@@ -1,11 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CluedIn.Core" />

--- a/src/ExternalSearch.Providers.ClearBit.Provider/Provider.ExternalSearch.ClearBit.csproj
+++ b/src/ExternalSearch.Providers.ClearBit.Provider/Provider.ExternalSearch.ClearBit.csproj
@@ -2,7 +2,6 @@
 
   <ItemGroup>
     <PackageReference Include="CluedIn.Core" />
-    <PackageReference Include="ComponentHost" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ExternalSearch.Providers.ClearBit/ClearBitExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.ClearBit/ClearBitExternalSearchProvider.cs
@@ -255,7 +255,7 @@ namespace CluedIn.ExternalSearch.Providers.ClearBit
             return configurableAcceptedEntityTypes.Any(entityTypeToEvaluate.Is);
         }
 
-        private ConnectionVerificationResult ConstructVerifyConnectionResponse(IRestResponse response)
+        private ConnectionVerificationResult ConstructVerifyConnectionResponse(RestResponse response)
         {
             var errorMessageBase = $"{Constants.ProviderName} returned \"{(int)response.StatusCode} {response.StatusDescription}\".";
             if (response.ErrorException != null)
@@ -296,9 +296,9 @@ namespace CluedIn.ExternalSearch.Providers.ClearBit
                 yield break;
 
             var client = new RestClient("https://autocomplete.clearbit.com");
-            var request = new RestRequest(string.Format("/v1/companies/suggest?query={0}", name ?? domain), Method.GET);
+            var request = new RestRequest(string.Format("/v1/companies/suggest?query={0}", name ?? domain), Method.Get);
 
-            var response = client.ExecuteTaskAsync<List<CompanyAutocompleteResult>>(request).Result;
+            var response = client.ExecuteAsync<List<CompanyAutocompleteResult>>(request).Result;
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -346,7 +346,7 @@ namespace CluedIn.ExternalSearch.Providers.ClearBit
         public ConnectionVerificationResult VerifyConnection(ExecutionContext context, IReadOnlyDictionary<string, object> config)
         {
             var client = new RestClient("https://autocomplete.clearbit.com");
-            var request = new RestRequest(string.Format("/v1/companies/suggest?query=Google"), Method.GET);
+            var request = new RestRequest(string.Format("/v1/companies/suggest?query=Google"), Method.Get);
 
             var response = client.ExecuteAsync<List<CompanyAutocompleteResult>>(request).Result;
 

--- a/src/ExternalSearch.Providers.ClearBit/Disabled_ClearBitDomainExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.ClearBit/Disabled_ClearBitDomainExternalSearchProvider.cs
@@ -121,10 +121,10 @@ namespace CluedIn.ExternalSearch.Providers.ClearBit
             var sharedApiToken = ConfigurationManagerEx.AppSettings["Providers.ExternalSearch.ClearBit.ApiToken"];
 
             var client = new RestClient("https://person-stream.clearbit.com");
-            var request = new RestRequest(string.Format("/v2/combined/find?email={0}", name), Method.GET);
+            var request = new RestRequest(string.Format("/v2/combined/find?email={0}", name), Method.Get);
             request.AddHeader("Authorization", "Bearer " + sharedApiToken);
 
-            var response = client.ExecuteTaskAsync<ClearbitResponse>(request).Result;
+            var response = client.ExecuteAsync<ClearbitResponse>(request).Result;
 
             if (response.StatusCode == HttpStatusCode.OK)
             {

--- a/src/ExternalSearch.Providers.ClearBit/Disabled_ClearBitEmployeeExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.ClearBit/Disabled_ClearBitEmployeeExternalSearchProvider.cs
@@ -104,12 +104,12 @@ namespace CluedIn.ExternalSearch.Providers.ClearBit
             var sharedApiToken = ConfigurationManagerEx.AppSettings["Providers.ExternalSearch.ClearBit.ApiToken"];
 
             var client = new RestClient("https://prospector.clearbit.com");
-            var request = new RestRequest(string.Format("/v1/people/search"), Method.GET);
+            var request = new RestRequest(string.Format("/v1/people/search"), Method.Get);
             request.AddParameter("domain", name);
             request.AddParameter("limit", 20);
             request.AddHeader("Authorization", "Bearer " + sharedApiToken);
 
-            var response = client.ExecuteTaskAsync<ClearbitResponse>(request).Result;
+            var response = client.ExecuteAsync<ClearbitResponse>(request).Result;
 
             if (response.StatusCode == HttpStatusCode.OK)
             {

--- a/src/ExternalSearch.Providers.ClearBit/Disabled_ClearBitIPExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.ClearBit/Disabled_ClearBitIPExternalSearchProvider.cs
@@ -90,10 +90,10 @@ namespace CluedIn.ExternalSearch.Providers.ClearBit
             var sharedApiToken = ConfigurationManagerEx.AppSettings["Providers.ExternalSearch.ClearBit.ApiToken"];
 
             var client = new RestClient("https://reveal.clearbit.com");
-            var request = new RestRequest(string.Format("/v1/companies/find?ip={0}", name), Method.GET);
+            var request = new RestRequest(string.Format("/v1/companies/find?ip={0}", name), Method.Get);
             request.AddHeader("Authorization", "Bearer " + sharedApiToken);
 
-            var response = client.ExecuteTaskAsync<ClearbitResponse>(request).Result;
+            var response = client.ExecuteAsync<ClearbitResponse>(request).Result;
 
             if (response.StatusCode == HttpStatusCode.OK)
             {

--- a/src/ExternalSearch.Providers.ClearBit/ExternalSearch.Providers.ClearBit.csproj
+++ b/src/ExternalSearch.Providers.ClearBit/ExternalSearch.Providers.ClearBit.csproj
@@ -11,7 +11,6 @@
     <EmbeddedResource Include="Resources\clearbit-vector-logo.svg" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ComponentHost" />
     <PackageReference Include="CluedIn.Core" />
     <PackageReference Include="CluedIn.ExternalSearch" />
     <PackageReference Include="CluedIn.Processing" />

--- a/src/ExternalSearch.Providers.ClearBit/ExternalSearch.Providers.ClearBit.csproj
+++ b/src/ExternalSearch.Providers.ClearBit/ExternalSearch.Providers.ClearBit.csproj
@@ -18,7 +18,4 @@
     <PackageReference Include="CluedIn.Processing.Web" />
     <PackageReference Include="CluedIn.Processing.Web.TechnologyDetection" />
   </ItemGroup>
-  <PropertyGroup>
-    <LangVersion>preview</LangVersion>
-  </PropertyGroup>
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2"/>
+    <PackageReference Include="AutoFixture.Xunit3"/>
     <PackageReference Include="coverlet.msbuild"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.v3"/>
     <PackageReference Include="xunit.runner.visualstudio"/>
     <PackageReference Include="Moq"/>
     <PackageReference Include="Shouldly"/>

--- a/test/integration/ExternalSearch.ClearBit.Integration.Tests/ClearBitTests.cs
+++ b/test/integration/ExternalSearch.ClearBit.Integration.Tests/ClearBitTests.cs
@@ -8,11 +8,11 @@ using CluedIn.Core.Serialization;
 using CluedIn.Core.Workflows;
 using CluedIn.ExternalSearch;
 using CluedIn.ExternalSearch.Providers.ClearBit;
-using CluedIn.Testing.Base.Context;
 using CluedIn.Testing.Base.ExternalSearch;
 using CluedIn.Testing.Base.Processing.Actors;
 using Moq;
 using Xunit;
+using TestContext = CluedIn.Testing.Base.Context.TestContext;
 
 namespace ExternalSearch.ClearBit.Integration.Tests
 {
@@ -52,10 +52,10 @@ namespace ExternalSearch.ClearBit.Integration.Tests
             context.Workflow        = command.Workflow;
 
             // Act
-            var result = actor.ProcessWorkflowStep(context, command);
+            var result = actor.ProcessWorkflowStepAsync(context, command).GetAwaiter().GetResult();
             Assert.Equal(WorkflowStepResult.Repeat.SaveResult, result.SaveResult);
 
-            result = actor.ProcessWorkflowStep(context, command);
+            result = actor.ProcessWorkflowStepAsync(context, command).GetAwaiter().GetResult();
             Assert.Equal(WorkflowStepResult.Success.SaveResult, result.SaveResult);
             context.Workflow.AddStepResult(result);
             


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: [AB#56314](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56314)

Upgrade to .NET 10 (`net10.0`) and align with CluedIn platform 5.0.

- `global.json`: SDK updated to `10.0.100` with `rollForward: latestFeature`
- `Directory.Build.props`: `TargetFramework` changed to `net10.0`; `LangVersion` removed (defaults to C# 13)
- `gitversion.yml`: `next-version` bumped to `5.0`
- CluedIn package references updated to `5.0.0-*`